### PR TITLE
Update RoxygenNote and document hai_data_* recipe changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: false
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2.9000
+RoxygenNote: 7.3.3
 URL: https://www.spsanderson.com/healthyR.ai/, https://github.com/spsanderson/healthyR.ai
 BugReports: https://github.com/spsanderson/healthyR.ai/issues
 Imports: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # healthyR.ai (development version)
 
+## Breaking Changes
+1. Fix #355 - Ensure that all `hai_data_*` functions that return a new recipe
+object all have the same name. The new name for the updated recipe object is:
+`new_rec_obj`.
+
+## New Features
+None
+
+## Minor Fixes and Improvements
+None
+
 # healthyR.ai 0.1.1
 
 ## Breaking Changes


### PR DESCRIPTION
Bump RoxygenNote to 7.3.3 in DESCRIPTION. Update NEWS.md to document breaking change: all hai_data_* functions now return updated recipe objects named 'new_rec_obj' for consistency (fixes #355).