### PR TITLE
Refactor documentation and update pkgdown config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -54,6 +54,9 @@ reference:
   -  title: Data Preprocessors
      contents:
      -  has_concept("Preprocessor")
+  -  title: Data Transformer Recipes
+     contents:
+     -  has_concept("Data Recipes")
   -  title: Recipe Steps
      desc: Functions to add recipe steps
      contents:

--- a/man/hai_c50_data_prepper.Rd
+++ b/man/hai_c50_data_prepper.Rd
@@ -44,11 +44,6 @@ get_juiced_data(rec_obj)
 
 Other Preprocessor: 
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},

--- a/man/hai_cubist_data_prepper.Rd
+++ b/man/hai_cubist_data_prepper.Rd
@@ -40,11 +40,6 @@ get_juiced_data(rec_obj)
 
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},

--- a/man/hai_data_impute.Rd
+++ b/man/hai_data_impute.Rd
@@ -86,7 +86,7 @@ hai_data_impute(
   value,
   .type_of_imputation = "roll",
   .roll_statistic = median
-)$impute_rec_obj \%>\%
+)$new_rec_obj \%>\%
   get_juiced_data()
 
 }
@@ -147,24 +147,8 @@ Other Data Recipes:
 \code{\link{hai_data_transform}()},
 \code{\link{hai_data_trig}()},
 \code{\link{pca_your_recipe}()}
-
-Other Preprocessor: 
-\code{\link{hai_c50_data_prepper}()},
-\code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
-\code{\link{hai_earth_data_prepper}()},
-\code{\link{hai_glmnet_data_prepper}()},
-\code{\link{hai_knn_data_prepper}()},
-\code{\link{hai_ranger_data_prepper}()},
-\code{\link{hai_svm_poly_data_prepper}()},
-\code{\link{hai_svm_rbf_data_prepper}()},
-\code{\link{hai_xgboost_data_prepper}()}
 }
 \author{
 Steven P. Sanderson II, MPH
 }
 \concept{Data Recipes}
-\concept{Preprocessor}

--- a/man/hai_data_poly.Rd
+++ b/man/hai_data_poly.Rd
@@ -47,7 +47,7 @@ rec_obj <- recipe(value ~ ., df_tbl)
 hai_data_poly(
   .recipe_object = rec_obj,
   value
-)$scale_rec_obj \%>\%
+)$new_rec_obj \%>\%
   get_juiced_data()
 
 }
@@ -60,24 +60,8 @@ Other Data Recipes:
 \code{\link{hai_data_transform}()},
 \code{\link{hai_data_trig}()},
 \code{\link{pca_your_recipe}()}
-
-Other Preprocessor: 
-\code{\link{hai_c50_data_prepper}()},
-\code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
-\code{\link{hai_earth_data_prepper}()},
-\code{\link{hai_glmnet_data_prepper}()},
-\code{\link{hai_knn_data_prepper}()},
-\code{\link{hai_ranger_data_prepper}()},
-\code{\link{hai_svm_poly_data_prepper}()},
-\code{\link{hai_svm_rbf_data_prepper}()},
-\code{\link{hai_xgboost_data_prepper}()}
 }
 \author{
 Steven P. Sanderson II, MPH
 }
 \concept{Data Recipes}
-\concept{Preprocessor}

--- a/man/hai_data_scale.Rd
+++ b/man/hai_data_scale.Rd
@@ -71,7 +71,7 @@ hai_data_scale(
   .recipe_object = rec_obj,
   value,
   .type_of_scale = "center"
-)$scale_rec_obj \%>\%
+)$new_rec_obj \%>\%
   get_juiced_data()
 
 }
@@ -113,24 +113,8 @@ Other Data Recipes:
 \code{\link{hai_data_transform}()},
 \code{\link{hai_data_trig}()},
 \code{\link{pca_your_recipe}()}
-
-Other Preprocessor: 
-\code{\link{hai_c50_data_prepper}()},
-\code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
-\code{\link{hai_earth_data_prepper}()},
-\code{\link{hai_glmnet_data_prepper}()},
-\code{\link{hai_knn_data_prepper}()},
-\code{\link{hai_ranger_data_prepper}()},
-\code{\link{hai_svm_poly_data_prepper}()},
-\code{\link{hai_svm_rbf_data_prepper}()},
-\code{\link{hai_xgboost_data_prepper}()}
 }
 \author{
 Steven P. Sanderson II, MPH
 }
 \concept{Data Recipes}
-\concept{Preprocessor}

--- a/man/hai_data_transform.Rd
+++ b/man/hai_data_transform.Rd
@@ -116,7 +116,7 @@ hai_data_transform(
   .recipe_object = rec_obj,
   value,
   .type_of_scale = "log"
-)$scale_rec_obj \%>\%
+)$new_rec_obj \%>\%
   get_juiced_data()
 
 }
@@ -157,24 +157,8 @@ Other Data Recipes:
 \code{\link{hai_data_scale}()},
 \code{\link{hai_data_trig}()},
 \code{\link{pca_your_recipe}()}
-
-Other Preprocessor: 
-\code{\link{hai_c50_data_prepper}()},
-\code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_trig}()},
-\code{\link{hai_earth_data_prepper}()},
-\code{\link{hai_glmnet_data_prepper}()},
-\code{\link{hai_knn_data_prepper}()},
-\code{\link{hai_ranger_data_prepper}()},
-\code{\link{hai_svm_poly_data_prepper}()},
-\code{\link{hai_svm_rbf_data_prepper}()},
-\code{\link{hai_xgboost_data_prepper}()}
 }
 \author{
 Steven P. Sanderson II, MPH
 }
 \concept{Data Recipes}
-\concept{Preprocessor}

--- a/man/hai_data_trig.Rd
+++ b/man/hai_data_trig.Rd
@@ -61,7 +61,7 @@ hai_data_trig(
   .recipe_object = rec_obj,
   value,
   .type_of_scale = "sinh"
-)$scale_rec_obj \%>\%
+)$new_rec_obj \%>\%
   get_juiced_data()
 
 }
@@ -74,24 +74,8 @@ Other Data Recipes:
 \code{\link{hai_data_scale}()},
 \code{\link{hai_data_transform}()},
 \code{\link{pca_your_recipe}()}
-
-Other Preprocessor: 
-\code{\link{hai_c50_data_prepper}()},
-\code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_earth_data_prepper}()},
-\code{\link{hai_glmnet_data_prepper}()},
-\code{\link{hai_knn_data_prepper}()},
-\code{\link{hai_ranger_data_prepper}()},
-\code{\link{hai_svm_poly_data_prepper}()},
-\code{\link{hai_svm_rbf_data_prepper}()},
-\code{\link{hai_xgboost_data_prepper}()}
 }
 \author{
 Steven P. Sanderson II, MPH
 }
 \concept{Data Recipes}
-\concept{Preprocessor}

--- a/man/hai_earth_data_prepper.Rd
+++ b/man/hai_earth_data_prepper.Rd
@@ -51,11 +51,6 @@ get_juiced_data(cla_obj)
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},
 \code{\link{hai_ranger_data_prepper}()},

--- a/man/hai_glmnet_data_prepper.Rd
+++ b/man/hai_glmnet_data_prepper.Rd
@@ -42,11 +42,6 @@ get_juiced_data(rec_obj)
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},
 \code{\link{hai_ranger_data_prepper}()},

--- a/man/hai_knn_data_prepper.Rd
+++ b/man/hai_knn_data_prepper.Rd
@@ -43,11 +43,6 @@ get_juiced_data(rec_obj)
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_ranger_data_prepper}()},

--- a/man/hai_ranger_data_prepper.Rd
+++ b/man/hai_ranger_data_prepper.Rd
@@ -50,11 +50,6 @@ get_juiced_data(cla_obj)
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},

--- a/man/hai_svm_poly_data_prepper.Rd
+++ b/man/hai_svm_poly_data_prepper.Rd
@@ -50,11 +50,6 @@ get_juiced_data(cla_obj)
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},

--- a/man/hai_svm_rbf_data_prepper.Rd
+++ b/man/hai_svm_rbf_data_prepper.Rd
@@ -50,11 +50,6 @@ get_juiced_data(cla_obj)
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},

--- a/man/hai_xgboost_data_prepper.Rd
+++ b/man/hai_xgboost_data_prepper.Rd
@@ -50,11 +50,6 @@ get_juiced_data(cla_obj)
 Other Preprocessor: 
 \code{\link{hai_c50_data_prepper}()},
 \code{\link{hai_cubist_data_prepper}()},
-\code{\link{hai_data_impute}()},
-\code{\link{hai_data_poly}()},
-\code{\link{hai_data_scale}()},
-\code{\link{hai_data_transform}()},
-\code{\link{hai_data_trig}()},
 \code{\link{hai_earth_data_prepper}()},
 \code{\link{hai_glmnet_data_prepper}()},
 \code{\link{hai_knn_data_prepper}()},


### PR DESCRIPTION
Removed redundant 'Other Preprocessor' references from multiple Rd files and updated object names in examples to use 'new_rec_obj'. Added a new 'Data Transformer Recipes' section to the _pkgdown.yml configuration for improved documentation structure.